### PR TITLE
Security updates

### DIFF
--- a/JWT.podspec
+++ b/JWT.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'JWT'
-  s.version      = '1.1.3'
+  s.version      = '2.0.0'
   s.summary      = 'A JSON Web Token implementation in Objective-C.'
   s.homepage     = 'https://github.com/yourkarma/jwt'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }

--- a/JWT/Algorithms/JWTAlgorithm.h
+++ b/JWT/Algorithms/JWTAlgorithm.h
@@ -11,10 +11,24 @@
 @protocol JWTAlgorithm <NSObject>
 
 @required
+
 @property (nonatomic, readonly, copy) NSString *name;
 
+/**
+ Encodes and encrypts the provided payload using the provided secret key
+ @param theString The string to encode
+ @param theSecret The secret to use for encryption
+ @return An NSData object containing the encrypted payload, or nil if something went wrong.
+ */
 - (NSData *)encodePayload:(NSString *)theString withSecret:(NSString *)theSecret;
 
-@optional - (BOOL)verifySignedInput:(NSString *)input withSignature:(NSString *)signature;
+/**
+ Verifies the provided signature using the signed input and verification key
+ @param input The header and payload encoded string
+ @param signature The JWT provided signature
+ @param verificationKey The key to use for verifying the signature
+ @return YES if the provided signature is valid, NO otherwise
+ */
+- (BOOL)verifySignedInput:(NSString *)input withSignature:(NSString *)signature verificationKey:(NSString *)verificationKey;
 
 @end

--- a/JWT/Algorithms/JWTAlgorithmHS256.m
+++ b/JWT/Algorithms/JWTAlgorithmHS256.m
@@ -10,6 +10,7 @@
 #import <CommonCrypto/CommonHMAC.h>
 
 #import "JWTAlgorithmHS256.h"
+#import "NSData+JWT.h"
 
 @implementation JWTAlgorithmHS256
 
@@ -26,6 +27,13 @@
     unsigned char cHMAC[CC_SHA256_DIGEST_LENGTH];
     CCHmac(kCCHmacAlgSHA256, cSecret, strlen(cSecret), cString, strlen(cString), cHMAC);
     return [[NSData alloc] initWithBytes:cHMAC length:sizeof(cHMAC)];
+}
+
+- (BOOL)verifySignedInput:(NSString *)input withSignature:(NSString *)signature verificationKey:(NSString *)verificationKey
+{
+    NSString *expectedSignature = [[self encodePayload:input withSecret:verificationKey] base64UrlEncodedString];
+    
+    return [expectedSignature isEqualToString:signature];
 }
 
 @end

--- a/JWT/Algorithms/JWTAlgorithmHS384.m
+++ b/JWT/Algorithms/JWTAlgorithmHS384.m
@@ -10,6 +10,7 @@
 #import <CommonCrypto/CommonHMAC.h>
 
 #import "JWTAlgorithmHS384.h"
+#import "NSData+JWT.h"
 
 @implementation JWTAlgorithmHS384
 
@@ -26,6 +27,13 @@
     unsigned char cHMAC[CC_SHA384_DIGEST_LENGTH];
     CCHmac(kCCHmacAlgSHA384, cSecret, strlen(cSecret), cString, strlen(cString), cHMAC);
     return [[NSData alloc] initWithBytes:cHMAC length:sizeof(cHMAC)];
+}
+
+- (BOOL)verifySignedInput:(NSString *)input withSignature:(NSString *)signature verificationKey:(NSString *)verificationKey
+{
+    NSString *expectedSignature = [[self encodePayload:input withSecret:verificationKey] base64UrlEncodedString];
+    
+    return [expectedSignature isEqualToString:signature];
 }
 
 @end

--- a/JWT/Algorithms/JWTAlgorithmHS512.m
+++ b/JWT/Algorithms/JWTAlgorithmHS512.m
@@ -10,6 +10,7 @@
 #import <CommonCrypto/CommonHMAC.h>
 
 #import "JWTAlgorithmHS512.h"
+#import "NSData+JWT.h"
 
 @implementation JWTAlgorithmHS512
 
@@ -26,6 +27,13 @@
     unsigned char cHMAC[CC_SHA512_DIGEST_LENGTH];
     CCHmac(kCCHmacAlgSHA512, cSecret, strlen(cSecret), cString, strlen(cString), cHMAC);
     return [[NSData alloc] initWithBytes:cHMAC length:sizeof(cHMAC)];
+}
+
+- (BOOL)verifySignedInput:(NSString *)input withSignature:(NSString *)signature verificationKey:(NSString *)verificationKey
+{
+    NSString *expectedSignature = [[self encodePayload:input withSecret:verificationKey] base64UrlEncodedString];
+    
+    return [expectedSignature isEqualToString:signature];
 }
 
 @end

--- a/JWT/Algorithms/JWTAlgorithmNone.m
+++ b/JWT/Algorithms/JWTAlgorithmNone.m
@@ -18,8 +18,19 @@
     return [NSData data];
 }
 
-- (BOOL)verifySignedInput:(NSString *)input withSignature:(NSString *)signature {
-	return YES;
+- (BOOL)verifySignedInput:(NSString *)input withSignature:(NSString *)signature verificationKey:(NSString *)verificationKey
+{
+    //if a secret is provided, this isn't the None algorithm
+    if (verificationKey && ![verificationKey isEqualToString:@""]) {
+        return NO;
+    }
+    
+    //If the signature isn't blank, this isn't the None algorithm
+    if (signature && ![signature isEqualToString:@""]) {
+        return NO;
+    }
+    
+    return YES;
 }
 
 @end

--- a/JWT/Algorithms/JWTAlgorithmRS256.h
+++ b/JWT/Algorithms/JWTAlgorithmRS256.h
@@ -8,8 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "JWTAlgorithm.h"
-#import "JWTAlgorithmNone.h"
 
-@interface JWTAlgorithmRS256 : JWTAlgorithmNone //NSObject <JWTAlgorithm>
+@interface JWTAlgorithmRS256 : NSObject <JWTAlgorithm>
 
 @end

--- a/JWT/Algorithms/JWTAlgorithmRS256.m
+++ b/JWT/Algorithms/JWTAlgorithmRS256.m
@@ -20,8 +20,9 @@
   return nil;
 }
 
-- (BOOL)verifySignedInput:(NSString *)input withSignature:(NSString *)signature
+- (BOOL)verifySignedInput:(NSString *)input withSignature:(NSString *)signature verificationKey:(NSString *)verificationKey
 {
+    //Algorithm isn't implemented
     return NO;
 }
 

--- a/JWT/Algorithms/JWTAlgorithmRS256.m
+++ b/JWT/Algorithms/JWTAlgorithmRS256.m
@@ -20,4 +20,9 @@
   return nil;
 }
 
+- (BOOL)verifySignedInput:(NSString *)input withSignature:(NSString *)signature
+{
+    return NO;
+}
+
 @end

--- a/JWT/JWT.h
+++ b/JWT/JWT.h
@@ -143,28 +143,113 @@ typedef NS_ENUM(NSInteger, JWTError) {
 + (JWTBuilder *)encodeClaimsSet:(JWTClaimsSet *)claimsSet;
 + (JWTBuilder *)decodeMessage:(NSString *)message;
 
+/**
+ The JWT in it's encoded form. Will be decoded and verified
+ */
 @property (copy, nonatomic, readonly) NSString *jwtMessage;
+
+/**
+ The payload dictionary to encode
+ */
 @property (copy, nonatomic, readonly) NSDictionary *jwtPayload;
+
+/**
+ The header dictionary to encode
+ */
 @property (copy, nonatomic, readonly) NSDictionary *jwtHeaders;
+
+/**
+ The expected JWTClaimsSet to compare against a decoded JWT
+ */
 @property (copy, nonatomic, readonly) JWTClaimsSet *jwtClaimsSet;
+
+/**
+ The verification key to use when encoding/decoding a JWT
+ */
 @property (copy, nonatomic, readonly) NSString *jwtSecret;
+
+/**
+ Contains the error that occured during an operation, or nil if no error occured
+ */
 @property (copy, nonatomic, readonly) NSError *jwtError;
+
+/**
+ The <JWTAlgorithm> to use for encoding a JWT
+ */
 @property (strong, nonatomic, readonly) id<JWTAlgorithm> jwtAlgorithm;
+
+/**
+ The algorithm name to use for decoding the JWT. Required unless force decode is true
+ */
 @property (copy, nonatomic, readonly) NSString *jwtAlgorithmName;
+
+/**
+ The force decode option. If set to true, a JWT won't be validated before decoding.
+ Should only be used for debugging
+ */
 @property (copy, nonatomic, readonly) NSNumber *jwtOptions;
+
+/*
+ Optional algorithm name whitelist. If non-null, a JWT can only be decoded using an algorithm
+ specified on this list.
+ */
 @property (copy, nonatomic, readonly) NSSet *algorithmWhitelist;
 
+/**
+ Sets jwtMessage and returns the JWTBuilder to allow for method chaining
+ */
 @property (copy, nonatomic, readonly) JWTBuilder *(^message)(NSString *message);
+
+/**
+ Sets jwtPayload and returns the JWTBuilder to allow for method chaining
+ */
 @property (copy, nonatomic, readonly) JWTBuilder *(^payload)(NSDictionary *payload);
+
+/**
+ Sets jwtHeaders and returns the JWTBuilder to allow for method chaining
+ */
 @property (copy, nonatomic, readonly) JWTBuilder *(^headers)(NSDictionary *headers);
+
+/**
+ Sets jwtClaimsSet and returns the JWTBuilder to allow for method chaining
+ */
 @property (copy, nonatomic, readonly) JWTBuilder *(^claimsSet)(JWTClaimsSet *claimsSet);
+
+/**
+ Sets jwtSecret and returns the JWTBuilder to allow for method chaining
+ */
 @property (copy, nonatomic, readonly) JWTBuilder *(^secret)(NSString *secret);
+
+/**
+ Sets jwtAlgorithm and returns the JWTBuilder to allow for method chaining
+ */
 @property (copy, nonatomic, readonly) JWTBuilder *(^algorithm)(id<JWTAlgorithm>algorithm);
+
+/**
+ Sets jwtAlgorithmName and returns the JWTBuilder to allow for method chaining
+ */
 @property (copy, nonatomic, readonly) JWTBuilder *(^algorithmName)(NSString *algorithmName);
+
+/**
+ Sets jwtOptions and returns the JWTBuilder to allow for method chaining
+ */
 @property (copy, nonatomic, readonly) JWTBuilder *(^options)(NSNumber *options);
+
+/**
+ Sets algorithmWhitelist and returns the JWTBuilder to allow for method chaining
+ */
 @property (copy, nonatomic, readonly) JWTBuilder *(^whitelist)(NSArray *whitelist);
 
+/**
+ Creates the encoded JWT string based on the currently set properties, or nil if an
+ error occured
+ */
 @property (copy, nonatomic, readonly) NSString *encode;
+
+/**
+ Decodes and returns the JWT as a dictionary, based on the JWTBuilder's currently set
+ properties, or nil, if an error occured.
+ */
 @property (copy, nonatomic, readonly) NSDictionary *decode;
 
 @end

--- a/JWT/JWT.h
+++ b/JWT/JWT.h
@@ -27,52 +27,6 @@ typedef NS_ENUM(NSInteger, JWTError) {
 @class JWTBuilder;
 @interface JWT : NSObject
 
-#pragma mark - Algorithm Whitelist
-
-/**
- Enables/Disables the whitelisting mechanism. When enabled, only algorithms
- added to the whitelist can be used to verify JWTs. Any other algorithms will fail 
- validation.
- Whitelist is reset when toggled.
- 
- Defaults to disabled.
- @param enabled YES to enable whitelist, NO to disable.
- */
-+ (void)setWhitelistEnabled:(BOOL)enabled;
-
-/**
- The set of allowed algorithms for decoding. Verifying a JWT will fail if algorithm
- specified isn't on the whitelist.
- @return A copy of the Set of allowed algorithms
- */
-+ (NSSet *)algorithmWhitelist;
-
-/**
- Check if the current whitelist contains the given algorithm
- @param algorithmName The name of the algorithm to check for
- @return YES if the algorithm is whitelisted, NO otherwise.
- */
-+ (BOOL)whitelistContainsAlgorithm:(NSString *)algorithmName;
-
-/**
- Adds the specified algorithm name to the whitelist. Does nothing if the whitelist
- already contains the given algorithm.
- @param The name of the algorithm to add
- */
-+ (void)addAlgorithmToWhitelist:(NSString *)algorithmName;
-
-/**
- Removes the specified algorithm name to the whitelist. Does nothing if the whitelist
- doesn't contain the given algorithm.
- @param The name of the algorithm to remove
- */
-+ (void)removeAlgorithmFromWhitelist:(NSString *)algorithmName;
-
-/**
- Clears all entries from the algorithm whitelist
- */
-+ (void)clearWhitelist;
-
 #pragma mark - Encode
 + (NSString *)encodeClaimsSet:(JWTClaimsSet *)theClaimsSet withSecret:(NSString *)theSecret;
 + (NSString *)encodeClaimsSet:(JWTClaimsSet *)theClaimsSet withSecret:(NSString *)theSecret algorithm:(id<JWTAlgorithm>)theAlgorithm;
@@ -198,6 +152,7 @@ typedef NS_ENUM(NSInteger, JWTError) {
 @property (strong, nonatomic, readonly) id<JWTAlgorithm> jwtAlgorithm;
 @property (copy, nonatomic, readonly) NSString *jwtAlgorithmName;
 @property (copy, nonatomic, readonly) NSNumber *jwtOptions;
+@property (copy, nonatomic, readonly) NSSet *algorithmWhitelist;
 
 @property (copy, nonatomic, readonly) JWTBuilder *(^message)(NSString *message);
 @property (copy, nonatomic, readonly) JWTBuilder *(^payload)(NSDictionary *payload);
@@ -207,6 +162,7 @@ typedef NS_ENUM(NSInteger, JWTError) {
 @property (copy, nonatomic, readonly) JWTBuilder *(^algorithm)(id<JWTAlgorithm>algorithm);
 @property (copy, nonatomic, readonly) JWTBuilder *(^algorithmName)(NSString *algorithmName);
 @property (copy, nonatomic, readonly) JWTBuilder *(^options)(NSNumber *options);
+@property (copy, nonatomic, readonly) JWTBuilder *(^whitelist)(NSArray *whitelist);
 
 @property (copy, nonatomic, readonly) NSString *encode;
 @property (copy, nonatomic, readonly) NSDictionary *decode;

--- a/JWT/JWT.h
+++ b/JWT/JWT.h
@@ -28,15 +28,15 @@ typedef NS_ENUM(NSInteger, JWTError) {
 @interface JWT : NSObject
 
 #pragma mark - Encode
-+ (NSString *)encodeClaimsSet:(JWTClaimsSet *)theClaimsSet withSecret:(NSString *)theSecret;
-+ (NSString *)encodeClaimsSet:(JWTClaimsSet *)theClaimsSet withSecret:(NSString *)theSecret algorithm:(id<JWTAlgorithm>)theAlgorithm;
++ (NSString *)encodeClaimsSet:(JWTClaimsSet *)theClaimsSet withSecret:(NSString *)theSecret __attribute__((deprecated));
++ (NSString *)encodeClaimsSet:(JWTClaimsSet *)theClaimsSet withSecret:(NSString *)theSecret algorithm:(id<JWTAlgorithm>)theAlgorithm __attribute__((deprecated));
 
-+ (NSString *)encodePayload:(NSDictionary *)thePayload withSecret:(NSString *)theSecret;
-+ (NSString *)encodePayload:(NSDictionary *)thePayload withSecret:(NSString *)theSecret algorithm:(id<JWTAlgorithm>)theAlgorithm;
++ (NSString *)encodePayload:(NSDictionary *)thePayload withSecret:(NSString *)theSecret __attribute__((deprecated));
++ (NSString *)encodePayload:(NSDictionary *)thePayload withSecret:(NSString *)theSecret algorithm:(id<JWTAlgorithm>)theAlgorithm __attribute__((deprecated));
 
-+ (NSString *)encodePayload:(NSDictionary *)thePayload withSecret:(NSString *)theSecret withHeaders:(NSDictionary *)theHeaders algorithm:(id<JWTAlgorithm>)theAlgorithm;
++ (NSString *)encodePayload:(NSDictionary *)thePayload withSecret:(NSString *)theSecret withHeaders:(NSDictionary *)theHeaders algorithm:(id<JWTAlgorithm>)theAlgorithm __attribute__((deprecated));
 
-+ (NSString *)encodePayload:(NSDictionary *)thePayload withSecret:(NSString *)theSecret withHeaders:(NSDictionary *)theHeaders algorithm:(id<JWTAlgorithm>)theAlgorithm withError:(NSError * __autoreleasing *)theError;
++ (NSString *)encodePayload:(NSDictionary *)thePayload withSecret:(NSString *)theSecret withHeaders:(NSDictionary *)theHeaders algorithm:(id<JWTAlgorithm>)theAlgorithm withError:(NSError * __autoreleasing *)theError __attribute__((deprecated));
 
 //Will be deprecated in later releases
 #pragma mark - Decode
@@ -51,7 +51,7 @@ typedef NS_ENUM(NSInteger, JWTError) {
  @param theForcedOption BOOL indicating if verifying the JWT signature should be skipped. Should only be used for debugging
  @return A dictionary containing the header and payload dictionaries. Keyed to "header" and "payload", respectively. Or nil if an error occurs.
  */
-+ (NSDictionary *)decodeMessage:(NSString *)theMessage withSecret:(NSString *)theSecret withTrustedClaimsSet:(JWTClaimsSet *)theTrustedClaimsSet withError:(NSError *__autoreleasing *)theError withForcedAlgorithmByName:(NSString *)theAlgorithmName withForcedOption:(BOOL)theForcedOption;
++ (NSDictionary *)decodeMessage:(NSString *)theMessage withSecret:(NSString *)theSecret withTrustedClaimsSet:(JWTClaimsSet *)theTrustedClaimsSet withError:(NSError *__autoreleasing *)theError withForcedAlgorithmByName:(NSString *)theAlgorithmName withForcedOption:(BOOL)theForcedOption __attribute__((deprecated));
 
 /**
  Decodes a JWT and returns the decoded Header and Payload
@@ -62,7 +62,7 @@ typedef NS_ENUM(NSInteger, JWTError) {
  @param theAlgorithmName The name of the algorithm to use for verifying the signature. Required.
  @return A dictionary containing the header and payload dictionaries. Keyed to "header" and "payload", respectively. Or nil if an error occurs.
  */
-+ (NSDictionary *)decodeMessage:(NSString *)theMessage withSecret:(NSString *)theSecret withTrustedClaimsSet:(JWTClaimsSet *)theTrustedClaimsSet withError:(NSError *__autoreleasing *)theError withForcedAlgorithmByName:(NSString *)theAlgorithmName;
++ (NSDictionary *)decodeMessage:(NSString *)theMessage withSecret:(NSString *)theSecret withTrustedClaimsSet:(JWTClaimsSet *)theTrustedClaimsSet withError:(NSError *__autoreleasing *)theError withForcedAlgorithmByName:(NSString *)theAlgorithmName __attribute__((deprecated));
 
 /**
  Decodes a JWT and returns the decoded Header and Payload.
@@ -87,7 +87,7 @@ typedef NS_ENUM(NSInteger, JWTError) {
  @param skipVerification BOOL indicating if verifying the JWT signature should be skipped. Should only be used for debugging
  @return A dictionary containing the header and payload dictionaries. Keyed to "header" and "payload", respectively. Or nil if an error occurs.
  */
-+ (NSDictionary *)decodeMessage:(NSString *)theMessage withSecret:(NSString *)theSecret withError:(NSError *__autoreleasing *)theError withForcedAlgorithmByName:(NSString *)theAlgorithmName skipVerification:(BOOL)skipVerification;
++ (NSDictionary *)decodeMessage:(NSString *)theMessage withSecret:(NSString *)theSecret withError:(NSError *__autoreleasing *)theError withForcedAlgorithmByName:(NSString *)theAlgorithmName skipVerification:(BOOL)skipVerification __attribute__((deprecated));
 
 /**
  Decodes a JWT and returns the decoded Header and Payload
@@ -97,7 +97,7 @@ typedef NS_ENUM(NSInteger, JWTError) {
  @param theAlgorithmName The name of the algorithm to use for verifying the signature. Required.
  @return A dictionary containing the header and payload dictionaries. Keyed to "header" and "payload", respectively. Or nil if an error occurs.
  */
-+ (NSDictionary *)decodeMessage:(NSString *)theMessage withSecret:(NSString *)theSecret withError:(NSError *__autoreleasing *)theError withForcedAlgorithmByName:(NSString *)theAlgorithmName;
++ (NSDictionary *)decodeMessage:(NSString *)theMessage withSecret:(NSString *)theSecret withError:(NSError *__autoreleasing *)theError withForcedAlgorithmByName:(NSString *)theAlgorithmName __attribute__((deprecated));
 
 /**
  Decodes a JWT and returns the decoded Header and Payload
@@ -120,7 +120,7 @@ typedef NS_ENUM(NSInteger, JWTError) {
  @param theError Error pointer, if there is an error decoding the message, upon return contains an NSError object that describes the problem.
  @return A dictionary containing the header and payload dictionaries. Keyed to "header" and "payload", respectively. Or nil if an error occurs.
  */
-+ (NSDictionary *)decodeMessage:(NSString *)theMessage withSecret:(NSString *)theSecret withError:(NSError * __autoreleasing *)theError;
++ (NSDictionary *)decodeMessage:(NSString *)theMessage withSecret:(NSString *)theSecret withError:(NSError * __autoreleasing *)theError __attribute__((deprecated));
 
 /**
  Decodes a JWT and returns the decoded Header and Payload.
@@ -129,7 +129,7 @@ typedef NS_ENUM(NSInteger, JWTError) {
  @param theSecret The verification key to use for validating the JWT signature
  @return A dictionary containing the header and payload dictionaries. Keyed to "header" and "payload", respectively. Or nil if an error occurs. 
  */
-+ (NSDictionary *)decodeMessage:(NSString *)theMessage withSecret:(NSString *)theSecret;
++ (NSDictionary *)decodeMessage:(NSString *)theMessage withSecret:(NSString *)theSecret __attribute__((deprecated));
 
 #pragma mark - Builder
 + (JWTBuilder *)encodePayload:(NSDictionary *)payload;

--- a/JWT/JWT.m
+++ b/JWT/JWT.m
@@ -69,6 +69,10 @@ static NSObject *JWTAlgorithmWhitelistLock;
             resultString = @"It seems that json serialization failed for segment";
             break;
         }
+        case JWTUnspecifiedAlgorithmError: {
+            resultString = @"Unspecified algorithm! You must explicitly choose an algorithm to decode with.";
+            break;
+        }
         default: {
             resultString = @"Unexpected error";
             break;

--- a/JWTTests/Algorithms/JWTAlgorithmHS256Spec.m
+++ b/JWTTests/Algorithms/JWTAlgorithmHS256Spec.m
@@ -29,4 +29,28 @@ it(@"HMAC encodes the payload using SHA256", ^{
     [[[encodedPayload base64String] should] equal:@"uC/LeRrOxXhZuYm0MKgmSIzi5Hn9+SMmvQoug3WkK6Q="];
 });
 
+it(@"should verify JWT with valid signature and secret", ^{
+    NSString *secret = @"secret";
+    NSString *signingInput = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9";
+    NSString *signature = @"TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ";
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beTrue];
+});
+
+it(@"should fail to verify JWT with invalid secret", ^{
+    NSString *secret = @"notTheSecret";
+    NSString *signingInput = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9";
+    NSString *signature = @"TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ";
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beFalse];
+});
+
+it(@"should fail to verify JWT with invalid signature", ^{
+    NSString *secret = @"secret";
+    NSString *signingInput = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9";
+    NSString *signature = nil;
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beFalse];
+});
+
 SPEC_END

--- a/JWTTests/Algorithms/JWTAlgorithmHS384Spec.m
+++ b/JWTTests/Algorithms/JWTAlgorithmHS384Spec.m
@@ -29,4 +29,28 @@ it(@"HMAC encodes the payload using SHA384", ^{
     [[[encodedPayload base64String] should] equal:@"s62aZf5ZLMSvjtBQpY4kiJbYxSu8wLAUop2D9nod5Eqgd+nyUCEj+iaDuVuI4gaJ"];
 });
 
+it(@"should verify JWT with valid signature and secret", ^{
+    NSString *secret = @"secret";
+    NSString *signingInput = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9";
+    NSString *signature = @"hnzqaUFa2kfSFnynQ_WBJ7-wpLCgsyEdilCkRKliadjVuG-hGnc1qhvIjlvxSie5";
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beTrue];
+});
+
+it(@"should fail to verify JWT with invalid secret", ^{
+    NSString *secret = @"notTheSecret";
+    NSString *signingInput = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9";
+    NSString *signature = @"hnzqaUFa2kfSFnynQ_WBJ7-wpLCgsyEdilCkRKliadjVuG-hGnc1qhvIjlvxSie5";
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beFalse];
+});
+
+it(@"should fail to verify JWT with invalid signature", ^{
+    NSString *secret = @"secret";
+    NSString *signingInput = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9";
+    NSString *signature = nil;
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beFalse];
+});
+
 SPEC_END

--- a/JWTTests/Algorithms/JWTAlgorithmHS512Spec.m
+++ b/JWTTests/Algorithms/JWTAlgorithmHS512Spec.m
@@ -29,4 +29,29 @@ it(@"HMAC encodes the payload using SHA512", ^{
     [[[encodedPayload base64String] should] equal:@"KR3aqiPK+jqq4cl1U5H0vvNbvby5JzmlYYpciW9lINKw0o0tKYfayXR54xIUpR2Wz86voo5GpPlhtjxGNSoYng=="];
 });
 
+it(@"should verify JWT with valid signature and secret", ^{
+    JWTAlgorithmHS512 *algorithm = [[JWTAlgorithmHS512 alloc] init];
+    NSString *secret = @"secret";
+    NSString *signingInput = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9";
+    NSString *signature = @"SerC5MWQIs3fRH6ZD7gKKbq51TsyydXTvl23WpD9sA085SzQ7pK6M0TnYjFITNUkwuniGG5Is2OKJCEIHPn1Kg";
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beTrue];
+});
+
+it(@"should fail to verify JWT with invalid secret", ^{
+    NSString *secret = @"notTheSecret";
+    NSString *signingInput = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9";
+    NSString *signature = @"SerC5MWQIs3fRH6ZD7gKKbq51TsyydXTvl23WpD9sA085SzQ7pK6M0TnYjFITNUkwuniGG5Is2OKJCEIHPn1Kg";
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beFalse];
+});
+
+it(@"should fail to verify JWT with invalid signature", ^{
+    NSString *secret = @"secret";
+    NSString *signingInput = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9";
+    NSString *signature = nil;
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beFalse];
+});
+
 SPEC_END

--- a/JWTTests/Algorithms/JWTAlgorithmNoneSpec.m
+++ b/JWTTests/Algorithms/JWTAlgorithmNoneSpec.m
@@ -8,6 +8,7 @@
 
 #import <Kiwi/Kiwi.h>
 #import <Base64/MF_Base64Additions.h>
+#import "NSData+JWT.h"
 
 #import "JWTAlgorithmNone.h"
 
@@ -26,6 +27,30 @@ it(@"name is none", ^{
 it(@"should not encode payload and return emptry signature instead", ^{
     NSData *encodedPayload = [algorithm encodePayload:@"payload" withSecret:@"secret"];
     [[[encodedPayload base64Encoding] should] equal:@""];
+});
+
+it(@"should not verify JWT with a secret provided", ^{
+    NSString *secret = @"secret";
+    NSString *signingInput = @"eyJhbGciOiJub25lIn0.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ";
+    NSString *signature = nil;
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beFalse];
+});
+
+it(@"should not verify JWT with a signature provided", ^{
+    NSString *secret = nil;
+    NSString *signingInput = @"eyJhbGciOiJub25lIn0.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ";
+    NSString *signature = @"signed";
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beFalse];
+});
+
+it(@"should verify JWT with no signature and no secret provided", ^{
+    NSString *secret = nil;
+    NSString *signingInput = @"eyJhbGciOiJub25lIn0.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ";
+    NSString *signature = nil;
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beTrue];
 });
 
 SPEC_END

--- a/JWTTests/Algorithms/JWTAlgorithmRS256Spec.m
+++ b/JWTTests/Algorithms/JWTAlgorithmRS256Spec.m
@@ -32,4 +32,28 @@ it(@"HMAC encodes the payload using RSA256", ^{
     [[result should] equal:@(1)];//@"uC/LeRrOxXhZuYm0MKgmSIzi5Hn9+SMmvQoug3WkK6Q="];
 });
 
+it(@"should fail to verify JWT with valid signature and secret - RS256 not implemented yet", ^{
+    NSString *secret = @"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDdlatRjRjogo3WojgGHFHYLugdUWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUparCwlvdbH6dvEOfou0/gCFQsHUfQrSDv+MuSUMAe8jzKE4qW+jK+xQU9a03GUnKHkkle+Q0pX/g6jXZ7r1/xAK5Do2kQ+X5xK9cipRgEKwIDAQAB";
+    NSString *signingInput = @"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9";
+    NSString *signature = @"EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE";
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beFalse];
+});
+
+it(@"should fail to verify JWT with invalid secret", ^{
+    NSString *secret = @"notTheSecret";
+    NSString *signingInput = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9";
+    NSString *signature = @"EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE";
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beFalse];
+});
+
+it(@"should fail to verify JWT with invalid signature", ^{
+    NSString *secret = @"MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDdlatRjRjogo3WojgGHFHYLugdUWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUparCwlvdbH6dvEOfou0/gCFQsHUfQrSDv+MuSUMAe8jzKE4qW+jK+xQU9a03GUnKHkkle+Q0pX/g6jXZ7r1/xAK5Do2kQ+X5xK9cipRgEKwIDAQAB";
+    NSString *signingInput = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9";
+    NSString *signature = nil;
+    
+    [[theValue([algorithm verifySignedInput:signingInput withSignature:signature verificationKey:secret]) should] beFalse];
+});
+
 SPEC_END

--- a/JWTTests/JWTSpec.m
+++ b/JWTTests/JWTSpec.m
@@ -641,6 +641,25 @@ describe(@"Whitelist tests", ^{
     });
 });
 
+describe(@"Header tests", ^{
+    it(@"Header alg mismatch should fail verify", ^{
+        NSString *algorithmName = @"HS256";
+        NSString *secret = @"secret";
+        //Header specifies HS512
+        NSString *message = @"eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ";
+
+        
+        JWTBuilder *builder = [JWT decodeMessage:message].algorithmName(algorithmName).secret(secret);
+        
+        NSDictionary *decoded = builder.decode;
+        
+        [[builder.jwtError shouldNot] beNil];
+        [[theValue(builder.jwtError.code) should] equal:theValue(JWTUnsupportedAlgorithmError)];
+        [[decoded should] beNil];
+        
+    });
+});
+
 SPEC_END
 
 

--- a/JWTTests/JWTSpec.m
+++ b/JWTTests/JWTSpec.m
@@ -199,39 +199,108 @@ describe(@"encoding", ^{
     });
     
     context(@"none algorithm", ^{
-        it(@"encodes and decodes JWT with none algorithm", ^{
-        NSString *algorithmName = @"none";
-        NSString *secret = @"secret";
-        NSDictionary *payload = @{@"key": @"value"};
-        NSDictionary *headers = @{@"header" : @"value"};
-        
-        NSMutableDictionary *allHeaders = [@{@"typ":@"JWT", @"alg":algorithmName} mutableCopy];
-        
-        [allHeaders addEntriesFromDictionary:headers];
-        
-        NSString *headerSegment = [[NSJSONSerialization dataWithJSONObject:allHeaders options:0 error:nil] base64UrlEncodedString];
-        
-        NSString *payloadSegment = [[NSJSONSerialization dataWithJSONObject:payload options:0 error:nil] base64UrlEncodedString];
-        
-        NSString *signingInput = [@[headerSegment, payloadSegment] componentsJoinedByString:@"."];
-        
-        NSString *signingOutput = [[[JWTAlgorithmFactory algorithmByName:algorithmName] encodePayload:signingInput withSecret:secret] base64UrlEncodedString];
-        
-        NSString *jwt = [@[headerSegment, payloadSegment, signingOutput] componentsJoinedByString:@"."];
-        
-        NSDictionary *info = [JWT decodeMessage:jwt withSecret:secret];
-        NSLog(@"info is: %@", info);
-        
-        [[info[@"payload"] should] equal:payload];
-        [[info[@"header"] should] equal:allHeaders];
+        it(@"encodes and decodes JWT with none algorithm & nil secret", ^{
+            NSString *algorithmName = @"none";
+            NSString *secret = nil;
+            NSDictionary *payload = @{@"key": @"value"};
+            NSDictionary *headers = @{@"header" : @"value"};
+            
+            NSMutableDictionary *allHeaders = [@{@"typ":@"JWT", @"alg":algorithmName} mutableCopy];
+            
+            [allHeaders addEntriesFromDictionary:headers];
+            
+            NSString *headerSegment = [[NSJSONSerialization dataWithJSONObject:allHeaders options:0 error:nil] base64UrlEncodedString];
+            
+            NSString *payloadSegment = [[NSJSONSerialization dataWithJSONObject:payload options:0 error:nil] base64UrlEncodedString];
+            
+            NSString *signingInput = [@[headerSegment, payloadSegment] componentsJoinedByString:@"."];
+            
+            NSString *signingOutput = [[[JWTAlgorithmFactory algorithmByName:algorithmName] encodePayload:signingInput withSecret:secret] base64UrlEncodedString];
+            
+            NSString *jwt = [@[headerSegment, payloadSegment, signingOutput] componentsJoinedByString:@"."];
+            
+            NSDictionary *info = [JWT decodeMessage:jwt withSecret:secret];
+            NSLog(@"info is: %@", info);
+            
+            [[info[@"payload"] should] equal:payload];
+            [[info[@"header"] should] equal:allHeaders];
 
-        // fluent
-        info = [JWT decodeMessage:jwt].secret(secret).decode;
-        NSLog(@"info is: %@", info);
-        
-        [[info[@"payload"] should] equal:payload];
-        [[info[@"header"] should] equal:allHeaders];
+            // fluent
+            info = [JWT decodeMessage:jwt].secret(secret).decode;
+            NSLog(@"info is: %@", info);
+            
+            [[info[@"payload"] should] equal:payload];
+            [[info[@"header"] should] equal:allHeaders];
         });
+        
+        it(@"encodes and decodes JWT with none algorithm & blank secret", ^{
+            NSString *algorithmName = @"none";
+            NSString *secret = @"";
+            NSDictionary *payload = @{@"key": @"value"};
+            NSDictionary *headers = @{@"header" : @"value"};
+            
+            NSMutableDictionary *allHeaders = [@{@"typ":@"JWT", @"alg":algorithmName} mutableCopy];
+            
+            [allHeaders addEntriesFromDictionary:headers];
+            
+            NSString *headerSegment = [[NSJSONSerialization dataWithJSONObject:allHeaders options:0 error:nil] base64UrlEncodedString];
+            
+            NSString *payloadSegment = [[NSJSONSerialization dataWithJSONObject:payload options:0 error:nil] base64UrlEncodedString];
+            
+            NSString *signingInput = [@[headerSegment, payloadSegment] componentsJoinedByString:@"."];
+            
+            NSString *signingOutput = [[[JWTAlgorithmFactory algorithmByName:algorithmName] encodePayload:signingInput withSecret:secret] base64UrlEncodedString];
+            
+            NSString *jwt = [@[headerSegment, payloadSegment, signingOutput] componentsJoinedByString:@"."];
+            
+            NSDictionary *info = [JWT decodeMessage:jwt withSecret:secret];
+            NSLog(@"info is: %@", info);
+            
+            [[info[@"payload"] should] equal:payload];
+            [[info[@"header"] should] equal:allHeaders];
+            
+            // fluent
+            info = [JWT decodeMessage:jwt].secret(secret).decode;
+            NSLog(@"info is: %@", info);
+            
+            [[info[@"payload"] should] equal:payload];
+            [[info[@"header"] should] equal:allHeaders];
+        });
+        
+        it(@"fails to decoded JWT with none algorithm when secret specified", ^{
+            NSString *algorithmName = @"none";
+            NSString *secret = @"secret";
+            NSDictionary *payload = @{@"key": @"value"};
+            NSDictionary *headers = @{@"header" : @"value"};
+            
+            NSMutableDictionary *allHeaders = [@{@"typ":@"JWT", @"alg":algorithmName} mutableCopy];
+            
+            [allHeaders addEntriesFromDictionary:headers];
+            
+            NSString *headerSegment = [[NSJSONSerialization dataWithJSONObject:allHeaders options:0 error:nil] base64UrlEncodedString];
+            
+            NSString *payloadSegment = [[NSJSONSerialization dataWithJSONObject:payload options:0 error:nil] base64UrlEncodedString];
+            
+            NSString *signingInput = [@[headerSegment, payloadSegment] componentsJoinedByString:@"."];
+            
+            NSString *signingOutput = [[[JWTAlgorithmFactory algorithmByName:algorithmName] encodePayload:signingInput withSecret:secret] base64UrlEncodedString];
+            
+            NSString *jwt = [@[headerSegment, payloadSegment, signingOutput] componentsJoinedByString:@"."];
+            
+            NSDictionary *info = [JWT decodeMessage:jwt withSecret:secret];
+            NSLog(@"info is: %@", info);
+            
+            [[info[@"payload"] should] beNil];
+            [[info[@"header"] should] beNil];
+            
+            // fluent
+            info = [JWT decodeMessage:jwt].secret(secret).decode;
+            NSLog(@"info is: %@", info);
+            
+            [[info[@"payload"] should] beNil];
+            [[info[@"header"] should] beNil];
+        });
+
     });
 });
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ If you want to check claims while decoding, you could use next sample of code (a
 
     NSString *message = @"encodedJwt";
     NSString *secret = @"secret";
+    NSString *algorithmName = @"chosenAlgorithm"
 
-    JWTBuilder *builder = [JWT decodeMessage:jwt].secret(secret).claimsSet(trustedClaimsSet);
+    JWTBuilder *builder = [JWT decodeMessage:jwt].secret(secret).algorithmName(algorithmName).claimsSet(trustedClaimsSet);
     NSDictionary *payload = builder.decode;
     
     if (!builder.jwtError) {
@@ -81,7 +82,6 @@ Note: some attributes are encode-only or decode-only.
     *payload;
     *headers;
     *algorithm;
-    *algorithmName;
 
     #pragma mark - Decode only
     *message
@@ -125,8 +125,9 @@ You can set JWTBuilder attributes by fluent style (block interface).
     NSNumber *options = @(decodeForced);
     NSString *yourJwt = encodedResult; // from previous example
     NSString *yourSecret = secret; // from previous example
+    NSString *yourAlgorithm = algorithmName; // from previous example
     JWTBuilder *decodeBuilder = [JWT decodeMessage:yourJwt];
-    NSDictionary *decodedResult = decodeBuilder.message(yourJwt).secret(yourSecret).claimsSet(trustedClaimsSet).options(options).decode;
+    NSDictionary *decodedResult = decodeBuilder.message(yourJwt).secret(yourSecret).algorithmName(yourAlgorithm).claimsSet(trustedClaimsSet).options(options).decode;
     if (decodeBuilder.jwtError) {
         // handle error
         NSLog(@"decode failed, error: %@", decodeBuilder.jwtError);


### PR DESCRIPTION
Modified the JWTAlgorithm protocol to add a required function, verifySignedInput:withSignature:verificationKey, to allow the algorithm to provide it's own verification logic. 

Changed the RS256 algorithm to no longer subclass the None algorithm, it isn't implemented, so it should fail verification (unless force decode is enabled)

Also a few changes to make decoding JWTs more secure

1) Decoding a JWT requires you to specify the algorithm you want to use. Trusting the header's value of "alg" is not safe since the JWT hasn't been verified yet. You don't want to allow an attacker to choose the algorithm to verify their JWT with.
   - The decoding function will now error if the 'withForcedAlgorithmByName' parameter is not set. This can be skipped using the forcedOption still, but should only be done for debugging purposes.
   - Any decode functions that didn't explicitly take in an algorithm name use HS512 by default (which matches the default algorithm used by the encode functions). I believe these methods should be deprecated since you should always specify an algorithm

2) If the specified algorithm and the algorithm value provided by the header don't match, verification fails. You should always know what algorithm you're using, and if you receive a JWT with an unexpected "alg" value, something is fishy

3) Added an optional whitelist for algorithms. If enabled, decoding will fail for any algorithm that hasn't been added to the whitelist