### PR TITLE
Make JWT compileable on Mac OS

### DIFF
--- a/JWT/Algorithms/JWTAlgorithmRS256.m
+++ b/JWT/Algorithms/JWTAlgorithmRS256.m
@@ -9,6 +9,7 @@
 #import "JWTAlgorithmRS256.h"
 #import "MF_Base64Additions.h"
 #import <CommonCrypto/CommonCrypto.h>
+#import "Security+MissingSymbols.h"
 
 @implementation JWTAlgorithmRS256 {
     NSString *_privateKeyCertificatePassphrase;

--- a/JWT/Security/Security+MissingSymbols.h
+++ b/JWT/Security/Security+MissingSymbols.h
@@ -1,0 +1,32 @@
+#import <Security/Security.h>
+#import <TargetConditionals.h>
+
+#if TARGET_OS_MAC && !TARGET_OS_IPHONE
+/**
+    These symbols are available in the iOS 9.3 SDK and marked as "available in Mac OS X
+    10.7 and later", but are unavailable in the Mac headers for unknown reasons. They are
+    available in the binary, so adding their symbols like this both compiles and links
+    without issue.
+ */
+extern OSStatus SecKeyRawVerify(
+    SecKeyRef           key,
+	SecPadding          padding,
+	const uint8_t       *signedData,
+	size_t              signedDataLen,
+	const uint8_t       *sig,
+	size_t              sigLen)
+    __OSX_AVAILABLE_STARTING(__MAC_10_7, __IPHONE_2_0);
+
+extern OSStatus SecKeyRawSign(
+    SecKeyRef           key,
+	SecPadding          padding,
+	const uint8_t       *dataToSign,
+	size_t              dataToSignLen,
+	uint8_t             *sig,
+	size_t              *sigLen)
+    __OSX_AVAILABLE_STARTING(__MAC_10_7, __IPHONE_2_0);
+
+enum {
+    kSecPaddingPKCS1SHA256 = 0x8004,
+};
+#endif


### PR DESCRIPTION
yourkarma-JWT depends on SecKeyRawVerify and friends, which are available
on iOS, and according to the iOS header are available on Mac OS X since 10.7,
but which are missing from the Mac SDK headers.

This commit adds extern statements for these missing symbols so that JWT
builds on Mac as well, which works since these symbols are actually
available in the library, they're just not exported.

This bug is tracked with Apple at:
* http://www.openradar.me/25398055
* http://www.openradar.me/22067843