### PR TITLE
Avoid sending timestamps with decimal dot

### DIFF
--- a/Classes/ClaimSet/JWTClaimsSetSerializer.m
+++ b/Classes/ClaimSet/JWTClaimsSetSerializer.m
@@ -21,9 +21,9 @@
     [self dictionary:dictionary setObjectIfNotNil:theClaimsSet.issuer forKey:@"iss"];
     [self dictionary:dictionary setObjectIfNotNil:theClaimsSet.subject forKey:@"sub"];
     [self dictionary:dictionary setObjectIfNotNil:theClaimsSet.audience forKey:@"aud"];
-    [self dictionary:dictionary setObjectIfNotNil:@([theClaimsSet.expirationDate timeIntervalSince1970]) forKey:@"exp"];
-    [self dictionary:dictionary setObjectIfNotNil:@([theClaimsSet.notBeforeDate timeIntervalSince1970]) forKey:@"nbf"];
-    [self dictionary:dictionary setObjectIfNotNil:@([theClaimsSet.issuedAt timeIntervalSince1970]) forKey:@"iat"];
+    [self dictionary:dictionary setDateIfNotNil:theClaimsSet.expirationDate forKey:@"exp"];
+    [self dictionary:dictionary setDateIfNotNil:theClaimsSet.notBeforeDate forKey:@"nbf"];
+    [self dictionary:dictionary setDateIfNotNil:theClaimsSet.issuedAt forKey:@"iat"];
     [self dictionary:dictionary setObjectIfNotNil:theClaimsSet.identifier forKey:@"jti"];
     [self dictionary:dictionary setObjectIfNotNil:theClaimsSet.type forKey:@"typ"];
     return [dictionary copy];
@@ -50,5 +50,15 @@
     
     [theDictionary setObject:theObject forKey:theKey];
 }
+
++ (void)dictionary:(NSMutableDictionary *)theDictionary setDateIfNotNil:(NSDate*)date forKey:(id<NSCopying>)theKey;
+{
+    if (!date)
+        return;
+    NSNumber* value = @((unsigned long)[date timeIntervalSince1970]);
+    
+    [theDictionary setObject:value forKey:theKey];
+}
+
 
 @end

--- a/Tests/Tests/ClaimSet/JWTClaimsSerializerSpec.m
+++ b/Tests/Tests/ClaimSet/JWTClaimsSerializerSpec.m
@@ -15,50 +15,62 @@ SPEC_BEGIN(JWTClaimsSerializerSpec)
 context(@"serialization", ^{
     __block JWTClaimsSet *claimsSet;
     __block NSDictionary *serialized;
+
+    __block NSInteger expirationDateTS = 1234567;
+    __block NSInteger notBeforeDateTS = 1234321;
+    __block NSInteger issuedAtTS = 1234333;
     
     beforeEach(^{
+        
         claimsSet = [[JWTClaimsSet alloc] init];
         claimsSet.issuer = @"Facebook";
         claimsSet.subject = @"Token";
         claimsSet.audience = @"http://yourkarma.com";
-        claimsSet.expirationDate = [NSDate distantFuture];
-        claimsSet.notBeforeDate = [NSDate distantPast];
-        claimsSet.issuedAt = [NSDate date];
+        claimsSet.expirationDate = [NSDate dateWithTimeIntervalSince1970:expirationDateTS];
+        claimsSet.notBeforeDate = [NSDate dateWithTimeIntervalSince1970:notBeforeDateTS];
+        claimsSet.issuedAt = [NSDate dateWithTimeIntervalSince1970:issuedAtTS];
         claimsSet.identifier = @"thisisunique";
         claimsSet.type = @"test";
         serialized = [JWTClaimsSetSerializer dictionaryWithClaimsSet:claimsSet];
+        
+    });
+
+    it(@"number of serialized values", ^{
+        [[serialized should] haveCountOf:8];
     });
     
     it(@"serializes the issuer property", ^{
         [[serialized should] haveValue:claimsSet.issuer forKey:@"iss"];
     });
-
+    
     it(@"serializes the subject property", ^{
         [[serialized should] haveValue:claimsSet.subject forKey:@"sub"];
     });
-
+    
     it(@"serializes the audience property", ^{
         [[serialized should] haveValue:claimsSet.audience forKey:@"aud"];
     });
-
+    
     it(@"serializes the expiration date property", ^{
-        [[serialized should] haveValue:theValue([claimsSet.expirationDate timeIntervalSince1970]) forKey:@"exp"];
+        [[serialized should] haveValue:@(expirationDateTS) forKey:@"exp"];
     });
-
+    
     it(@"serializes the not before date property", ^{
-        [[serialized should] haveValue:theValue([claimsSet.notBeforeDate timeIntervalSince1970])  forKey:@"nbf"];
+        [[serialized should] haveValue:@(notBeforeDateTS)  forKey:@"nbf"];
     });
-
+    
     it(@"serializes the issued at property", ^{
-        [[serialized should] haveValue:theValue([claimsSet.issuedAt timeIntervalSince1970]) forKey:@"iat"];
+        [[serialized should] haveValue:@(issuedAtTS) forKey:@"iat"];
     });
-
+    
     it(@"serializes the JWT ID property", ^{
         [[serialized should] haveValue:claimsSet.identifier forKey:@"jti"];
+
     });
 
     it(@"serializes the type property", ^{
         [[serialized should] haveValue:claimsSet.type forKey:@"typ"];
+        
     });
 });
 
@@ -73,7 +85,7 @@ context(@"deserialization", ^{
             @"aud": @"http://yourkarma.com",
             @"exp": @(64092211200),
             @"nbf": @(-62135769600),
-            @"iat": @(1370005175.80196),
+            @"iat": @(1370005175),
             @"jti": @"thisisunique",
             @"typ": @"test"
         };


### PR DESCRIPTION
Fixes the cases when timestamp is being send as "12345.678", truncating it to "12345"