### PR TITLE
jwt: add scope property to claims set (needed for Google Cloud authentication)

### DIFF
--- a/Core/ClaimSet/JWTClaim.m
+++ b/Core/ClaimSet/JWTClaim.m
@@ -18,6 +18,7 @@
 // "iat" (Issued At) Claim
 // "jti" (JWT ID) Claim
 // "typ" (Type) Claim
+// "scope" (Scope) Claim
 
 @interface JWTClaimIssuer : JWTClaim
 
@@ -160,6 +161,22 @@
 
 @end
 
+@interface JWTClaimScope : JWTClaim
+
+@end
+
+@implementation JWTClaimScope
+
++ (NSString *)name {
+    return @"scope";
+}
+
++ (BOOL)verifyValue:(NSString *)value withTrustedValue:(NSString *)trustedValue {
+    return [trustedValue isEqualToString:value];
+}
+
+@end
+
 
 @implementation JWTClaim
 + (NSString *)name {
@@ -176,7 +193,8 @@
 		[JWTClaimNotBefore name] : [JWTClaimNotBefore new],
 		[JWTClaimIssuedAt name] : [JWTClaimIssuedAt new],
 		[JWTClaimJWTID name] : [JWTClaimJWTID new],
-		[JWTClaimType name] : [JWTClaimType new]
+		[JWTClaimType name] : [JWTClaimType new],
+        [JWTClaimScope name] : [JWTClaimScope new]
 	}, dictionary);
 }
 

--- a/Core/ClaimSet/JWTClaimsSet.h
+++ b/Core/ClaimSet/JWTClaimsSet.h
@@ -18,5 +18,6 @@
 @property (nonatomic, readwrite, copy) NSDate *issuedAt;
 @property (nonatomic, readwrite, copy) NSString *identifier;
 @property (nonatomic, readwrite, copy) NSString *type;
+@property (nonatomic, readwrite, copy) NSString *scope;
 
 @end

--- a/Core/ClaimSet/JWTClaimsSet.m
+++ b/Core/ClaimSet/JWTClaimsSet.m
@@ -21,7 +21,8 @@
     newClaimsSet.issuedAt = self.issuedAt;
     newClaimsSet.identifier = self.identifier;
     newClaimsSet.type = self.type;
-    
+    newClaimsSet.scope = self.scope;
+
     return newClaimsSet;
 }
 

--- a/Core/ClaimSet/JWTClaimsSetSerializer.m
+++ b/Core/ClaimSet/JWTClaimsSetSerializer.m
@@ -12,7 +12,7 @@
 
 + (NSArray *)claimsSetKeys
 {
-    return @[@"iss", @"sub", @"aud", @"exp", @"nbf", @"iat", @"jti", @"typ"];
+    return @[@"iss", @"sub", @"aud", @"exp", @"nbf", @"iat", @"jti", @"typ", @"scope"];
 }
 
 + (NSDictionary *)dictionaryWithClaimsSet:(JWTClaimsSet *)theClaimsSet;
@@ -26,6 +26,8 @@
     [self dictionary:dictionary setDateIfNotNil:theClaimsSet.issuedAt forKey:@"iat"];
     [self dictionary:dictionary setObjectIfNotNil:theClaimsSet.identifier forKey:@"jti"];
     [self dictionary:dictionary setObjectIfNotNil:theClaimsSet.type forKey:@"typ"];
+    [self dictionary:dictionary setObjectIfNotNil:theClaimsSet.scope forKey:@"scope"];
+
     return [dictionary copy];
 }
 
@@ -40,6 +42,8 @@
     claimsSet.issuedAt = [NSDate dateWithTimeIntervalSince1970:[[theDictionary objectForKey:@"iat"] doubleValue]];
     claimsSet.identifier = [theDictionary objectForKey:@"jti"];
     claimsSet.type = [theDictionary objectForKey:@"typ"];
+    claimsSet.scope = [theDictionary objectForKey:@"scope"];
+
     return claimsSet;
 }
 

--- a/Tests/Tests/ClaimSet/JWTClaimsSerializerSpec.m
+++ b/Tests/Tests/ClaimSet/JWTClaimsSerializerSpec.m
@@ -31,12 +31,13 @@ context(@"serialization", ^{
         claimsSet.issuedAt = [NSDate dateWithTimeIntervalSince1970:issuedAtTS];
         claimsSet.identifier = @"thisisunique";
         claimsSet.type = @"test";
+        claimsSet.scope = @"https://www.googleapis.com/auth/devstorage.read_write";
         serialized = [JWTClaimsSetSerializer dictionaryWithClaimsSet:claimsSet];
         
     });
 
     it(@"number of serialized values", ^{
-        [[serialized should] haveCountOf:8];
+        [[serialized should] haveCountOf:9];
     });
     
     it(@"serializes the issuer property", ^{
@@ -70,7 +71,12 @@ context(@"serialization", ^{
 
     it(@"serializes the type property", ^{
         [[serialized should] haveValue:claimsSet.type forKey:@"typ"];
-        
+
+    });
+
+    it(@"serializes the scope property", ^{
+        [[serialized should] haveValue:claimsSet.scope forKey:@"scope"];
+
     });
 });
 
@@ -87,7 +93,8 @@ context(@"deserialization", ^{
             @"nbf": @(-62135769600),
             @"iat": @(1370005175),
             @"jti": @"thisisunique",
-            @"typ": @"test"
+            @"typ": @"test",
+            @"scope": @"https://www.googleapis.com/auth/devstorage.read_write"
         };
         deserialized = [JWTClaimsSetSerializer claimsSetWithDictionary:serialized];
     });
@@ -119,9 +126,13 @@ context(@"deserialization", ^{
     it(@"deserializes the JWT ID property", ^{
         [[deserialized.identifier should] equal:[serialized objectForKey:@"jti"]];
     });
-    
+
     it(@"deserializes the type property", ^{
         [[deserialized.type should] equal:[serialized objectForKey:@"typ"]];
+    });
+
+    it(@"deserializes the scope property", ^{
+        [[deserialized.scope should] equal:[serialized objectForKey:@"scope"]];
     });
 });
         

--- a/Tests/Tests/JWT/JWTSpec.m
+++ b/Tests/Tests/JWT/JWTSpec.m
@@ -158,7 +158,8 @@ describe(@"encoding", ^{
                                      @"nbf": @(-62135769600),
                                      @"iat": @(1370005175.80196),
                                      @"jti": @"thisisunique",
-                                     @"typ": @"test"
+                                     @"typ": @"test",
+                                     @"scope": @"https://www.googleapis.com/auth/devstorage.read_write"
                                      };
         
         NSString *algorithmName = @"Test";
@@ -166,9 +167,9 @@ describe(@"encoding", ^{
         JWTClaimsSet *claimsSet = [JWTClaimsSetSerializer claimsSetWithDictionary:dictionary];
         
         NSString *headerSegment = [[NSJSONSerialization dataWithJSONObject:@{@"typ": @"JWT", @"alg": algorithmName} options:0 error:nil] base64UrlEncodedString];
-        
+
         NSString *payloadSegment = [[NSJSONSerialization dataWithJSONObject:dictionary options:0 error:nil] base64UrlEncodedString];
-        
+
         NSString *signingInput = [@[headerSegment, payloadSegment] componentsJoinedByString:@"."];
         
         NSString *signedOutput = @"signed";
@@ -183,8 +184,9 @@ describe(@"encoding", ^{
         [[algorithmMock should] receive:@selector(encodePayload:withSecret:) andReturn:signedOutput withCount:2 arguments:signingInput, secret];
         
         [JWTClaimsSetSerializer stub:@selector(dictionaryWithClaimsSet:) andReturn:dictionary];
-        
+
         [[[JWT encodeClaimsSet:claimsSet withSecret:secret algorithm:algorithmMock] should] equal:jwt];
+
         //fluent
         [[[JWT encodeClaimsSet:claimsSet].secret(secret).algorithm(algorithmMock).encode should] equal:jwt];
         });
@@ -471,6 +473,7 @@ describe(@"decoding", ^{
             claimsSet.issuedAt = [NSDate date];
             claimsSet.identifier = @"thisisunique";
             claimsSet.type = @"test";
+            claimsSet.scope = @"https://www.googleapis.com/auth/devstorage.read_write";
             
             
             NSDictionary *payload = [JWTClaimsSetSerializer dictionaryWithClaimsSet:claimsSet];//@{@"key": @"value"};


### PR DESCRIPTION
### New Pull Request Checklist

* [X] I have searched for a similar pull request in the [project](https://github.com/yourkarma/JWT/pulls) and found none

* [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [X] I have added the required tests to prove the fix/feature I am adding
* [X] I have updated the documentation (if necessary)
* [X] I have run the tests and they pass
* [X] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues:
Google Cloud service account authentication requires the client to specify an access scope in the JWT Claims Set.
See https://cloud.google.com/storage/docs/authentication#generating-a-private-key

### Pull Request Description
Add the .scope property to the JWTClaimsSet class.
...