### PR TITLE
Swift can't find the crypto key headers when creating the bridging fi…

### DIFF
--- a/Core/FrameworkSupplement/JWT.h
+++ b/Core/FrameworkSupplement/JWT.h
@@ -44,3 +44,8 @@ FOUNDATION_EXPORT const unsigned char JWTVersionString[];
 #import <JWT/JWTDeprecations.h>
 #import <JWT/JWTBase64Coder.h>
 #import <JWT/JWTErrorDescription.h>
+
+// Crypto
+#import <JWT/JWTCryptoKey.h>
+#import <JWT/JWTCryptoKeyExtractor.h>
+#import <JWT/JWTCryptoSecurity.h>


### PR DESCRIPTION
…le. Updated the Umbrella file to include the missing headers. This enables the use of RSA JWT public keys via a pen file.

### New Pull Request Checklist

* [x] I have searched for a similar pull request in the [project](https://github.com/yourkarma/JWT/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding (Not testable)
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass (None addable, it's header files)
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

When using the latest beta (for RSA 256 JWT public key pem file support) in swift, it's not possible to decode a JWT due to the fact that a crypto key extractor is needed in the creation of the special jwtbuilder class that handles public pems. The crypto header files are not included in the ubrella file that is used for the swift bridging file.
