### PR TITLE
core: jwt crypto security pem extraction fixed. vertical line was fatal.

### DIFF
--- a/Tests/Tests/JWT/JWTIssuesSpec.m
+++ b/Tests/Tests/JWT/JWTIssuesSpec.m
@@ -14,6 +14,10 @@
 
 SPEC_BEGIN(JWTIssuesSpec)
 describe(@"Issue examples", ^{
+    it(@"RS256 key should be read correctly from file", ^{
+        id key = [JWTCryptoSecurity keyFromPemFileWithName:@"rs256-public"];
+        NSLog(@"%@ key: %@", self.debugDescription, key);
+    });
     it(@"RS256 signature verification crashes application #141", ^{
         NSString *publicKey = @"MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAM/l2OJO6C6eZWwV4h2FooxI2YZ/XNL+BP7kEB7wiudqi0vGRAheahe+vtazFE+J3V1iy+bwIqLXop571zgj6G0CAwEAAQ==";
         NSString *algorithmName = JWTAlgorithmNameRS256;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have searched for a similar pull request in the [project](https://github.com/yourkarma/JWT/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

JWT Crypto Security possible bug fix.

- Vertical line was fatal in regex.
- Dirty lines after matching contain new line separators.