### PR TITLE
Fixing possible null dereference.

### DIFF
--- a/Core/Algorithms/RSFamily/RSKeys/JWTCryptoSecurity.m
+++ b/Core/Algorithms/RSFamily/RSKeys/JWTCryptoSecurity.m
@@ -110,7 +110,9 @@
         OSStatus copyItemStatus = SecItemCopyMatching((__bridge CFDictionaryRef)[self dictionaryByCombiningDictionaries:@[attributes, commonAttributes, copyAttributes]], &key);
         if (key == NULL) {
             // copy item error
-            *error = [NSError errorWithDomain:@"org.opensource.jwt" code:copyItemStatus userInfo:@{NSLocalizedDescriptionKey: @"error"}];
+            if (error) {
+                *error = [NSError errorWithDomain:@"org.opensource.jwt" code:copyItemStatus userInfo:@{NSLocalizedDescriptionKey: @"error"}];
+            }
         }
         return (SecKeyRef)key;
     }


### PR DESCRIPTION
According to coding standards in 'Creating and Returning NSError Objects' the parameter may be null

### New Pull Request Checklist

* [ ] I have searched for a similar pull request in the [project](https://github.com/yourkarma/JWT/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...
