### PR TITLE
Gets rid of not needed NSString in swift example

### DIFF
--- a/Example/JWTDesktopSwift/JWTDesktopSwift/String+Extension.swift
+++ b/Example/JWTDesktopSwift/JWTDesktopSwift/String+Extension.swift
@@ -21,11 +21,10 @@ extension String {
         guard let data = try? JSONSerialization.data(withJSONObject: jsonObject, options: .prettyPrinted) else {
             return ""
         }
-        
-        guard let string = NSString(data: data, encoding: String.Encoding.utf8.rawValue) else {
+
+        guard let string = String(data: data, encoding: .utf8) else {
             return ""
         }
-        
-        return string as String
+        return string
     }
 }


### PR DESCRIPTION
String-NSString bridging in Swift is not free

### New Pull Request Checklist

* [ ] I have searched for a similar pull request in the [project](https://github.com/yourkarma/JWT/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...
