### PR TITLE
Fixes string interpolation warnings in Swift example

### DIFF
--- a/Example/JWTDesktopSwift/JWTDesktopSwift/TokenDecoder.swift
+++ b/Example/JWTDesktopSwift/JWTDesktopSwift/TokenDecoder.swift
@@ -109,8 +109,8 @@ class JWTTokenDecoder__V3: TokenDecoder {
 
         let builder = JWTDecodingBuilder.decodeMessage(token).addHolder(holder)?.options(skipVerification as NSNumber)
         let result = builder?.result
-        print("JWT ERROR: \(String(describing: result?.errorResult?.debugDescription)) -> \(result?.errorResult?.error?.localizedDescription)")
-        print("JWT RESULT: \(String(describing: result?.successResult?.debugDescription)) -> \(result?.successResult?.headerAndPayloadDictionary?.debugDescription)")
+        print("JWT ERROR: \(String(describing: result?.errorResult?.debugDescription)) -> \(String(describing: result?.errorResult?.error?.localizedDescription))")
+        print("JWT RESULT: \(String(describing: result?.successResult?.debugDescription)) -> \(String(describing: result?.successResult?.headerAndPayloadDictionary?.debugDescription))")
         return result?.successResult?.headerAndPayloadDictionary
     }
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have searched for a similar pull request in the [project](https://github.com/yourkarma/JWT/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...
