### PR TITLE
Fixes crash when providing a pkcs12 file with only one private key in 

### DIFF
--- a/Core/Algorithms/RSFamily/RSKeys/JWTCryptoSecurity.m
+++ b/Core/Algorithms/RSFamily/RSKeys/JWTCryptoSecurity.m
@@ -185,6 +185,10 @@
                                     optionsDictionary,
                                     &items);                    // 2
     
+    if (CFArrayGetCount(items) == 0) {
+        securityError = errSecPkcs12VerifyFailure;
+    }
+    
     //
     if (securityError == 0) {                                   // 3
         CFDictionaryRef myIdentityAndTrust = CFArrayGetValueAtIndex (items, 0);


### PR DESCRIPTION
Added a patch to make sure the pkcs12 that were opened actually has the number of private - certificate pairs that are needed to continue. If a pkcs12 that was created with only one private key in it and no certificate was tried used, this just crashed when accessing index 0 with the CFArrayGetValueAtIndex