### PR TITLE
JWTDeprecations: Fix error when importing in ObjectiveC++.

### DIFF
--- a/Core/Supplement/JWTDeprecations.h
+++ b/Core/Supplement/JWTDeprecations.h
@@ -14,7 +14,7 @@
 #define JWTVersion_2_2_0 2.2
 #define JWTVersion_3_0_0 3.0
 #define __first_deprecated_in_release_version(version) __deprecated_msg("first deprecated in release version: " JWT_STR(version))
-#define __deprecated_and_will_be_removed_in_release_version(version) __deprecated_msg("deprecated. will be removed in release version: "JWT_STR(version))
+#define __deprecated_and_will_be_removed_in_release_version(version) __deprecated_msg("deprecated. will be removed in release version: " JWT_STR(version))
 #define __available_in_release_version(version) __deprecated_msg("will be introduced in release version: " JWT_STR(version))
 #define __jwt_technical_debt(debt) __deprecated_msg("Don't forget to inspect it later." JWT_STR(debt))
 #define __deprecated_with_replacement(msg) __deprecated_msg("Use " JWT_STR(msg))


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have searched for a similar pull request in the [project](https://github.com/yourkarma/JWT/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

Before merge, please, assure that your commits are grouped.
Please, don't make several PRs with single commit, group PRs into one if possible.

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Xcode errs with the following message when importing the file (or any
file that imports it) to an ObjectiveC++ file: `Invalid suffix on
literal; C++11 requires a space between literal and identifier`. To
solve this, a space is added before `JWT_STR`.

