### PR TITLE
Resolving package resolution issue in Xcode 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
             targets: ["JWT"]
         )
     ],
-    dependencies: [.package(url: "https://github.com/lolgear/Base64", ._branchItem("distribution/swift_package_manager_support"))],
+    dependencies: [.package(url: "https://github.com/lolgear/Base64", .branchItem("distribution/swift_package_manager_support"))],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.


### PR DESCRIPTION
When building, the package resolution was failing with Xcode 13. Removing the underscore ("_") fixes this issue from the dependencies item.
