### PR TITLE
Reset error after decoding message successfully

### DIFF
--- a/Sources/JWT/Coding/JWTCoding+VersionThree.m
+++ b/Sources/JWT/Coding/JWTCoding+VersionThree.m
@@ -623,7 +623,7 @@
                              JWTCodingResultComponents.headers : header,
                              JWTCodingResultComponents.payload : payload
                              };
-    
+    *theError = nil;
     return result;
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have searched for a similar pull request in the [project](https://github.com/yourkarma/JWT/pulls) and found none
- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)

Before merge, please, assure that your commits are grouped.
Please, don't make several PRs with single commit, group PRs into one if possible.

This merge request fixes / refers to the following issues: <N/A>

### Pull Request Description

My goal was to decode a JWT that can have different "alg" values: HS256, HS384, HS512. I noticed in the documentation that this should be possible using a `JWTAlgorithmDataHolderChain`.

However, if decoding doesn't succeed with the first holder (resulting in an error), the succeeding decoding attempts don't clear out the error even though one of them was successful. I think this issue is not noticeable if verification is being skipped. I also just noticed it when also providing secret data.

This is the interesting part:

https://github.com/yourkarma/JWT/blob/466a8e87b2299a97f48dce428f408e29a59cb761/Sources/JWT/Coding/JWTCoding%2BVersionThree.m#L446-L463

Calling `-[decodeMessage:secretData:algorithm:options:error:]` might lead to an error and it's never set to `nil` inside that method. That's why I'm setting it to `nil` in my PR. It's just one line of code that has changed and this fixes my issue.

I must admit that I didn't write any tests but hopefully my description and single line of code makes sense?